### PR TITLE
Fix loading animation

### DIFF
--- a/ui/src/components/AppButton.jsx
+++ b/ui/src/components/AppButton.jsx
@@ -15,7 +15,7 @@ export default function AppButton({ app, isLoading, isInstalled }) {
 
   useEffect(() => {
     if (isLoading) {
-      const ellipsis = ['', '.\u00A0\u00A0', '..\u00A0', '...']
+      const ellipsis = ['.\u00A0\u00A0', '..\u00A0', '...']
       let index = 0
       const interval = setInterval(() => {
         setAnimatedText(ellipsis[index])


### PR DESCRIPTION
This removes an extraneous frame from the loading animation that plays when you click the "GET" button. I thought about removing it on aesthetic grounds, but it also causes a glitch on many screen sizes where the height of the button's table row increases and decreases throughout the load time.