### PR TITLE
Normalize %app-titles

### DIFF
--- a/ui/src/components/AppTable.jsx
+++ b/ui/src/components/AppTable.jsx
@@ -64,7 +64,13 @@ function normalizeAppTitle(title) {
     return title;
   }
 
-  return title
+  let newTitle = title
+
+  if (newTitle.startsWith('%')) {
+    newTitle = newTitle.substring(1)
+  }
+
+  return newTitle
     .split(' ')
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');


### PR DESCRIPTION
Brings titles like `%emissary` in line with the rest of the app's style.