### PR TITLE
Normalize null website links

### DIFF
--- a/desk/mar/ui-update.hoon
+++ b/desk/mar/ui-update.hoon
@@ -49,7 +49,7 @@
               ['info' [%s info]]
               ['color' [%s (scot %ux color)]]
               ['image' [%s ?~(image '' (need image))]]
-              ['website' [%s website]]
+              ['website' [%s ?~((de-purl:html website) '' website)]]
               ['license' [%s license]]
               :-  'version'
               :-  %s
@@ -104,7 +104,7 @@
               ['info' [%s info]]
               ['color' [%s (scot %ux color)]]
               ['image' [%s ?~(image '' (need image))]]
-              ['website' [%s website]]
+              ['website' [%s ?~((de-purl:html website) '' website)]]
               ['license' [%s license]]
               :-  'version'
               :-  %s

--- a/ui/src/components/AppTable.jsx
+++ b/ui/src/components/AppTable.jsx
@@ -119,10 +119,6 @@ function normalizeWebsite(url) {
     return ''
   }
 
-  if (url === '~') {
-    return ''
-  }
-
   let newUrl = url
 
   if (newUrl.startsWith('web+urbitgraph://group/')) {

--- a/ui/src/components/AppTable.jsx
+++ b/ui/src/components/AppTable.jsx
@@ -119,6 +119,10 @@ function normalizeWebsite(url) {
     return ''
   }
 
+  if (url === '~') {
+    return ''
+  }
+
   let newUrl = url
 
   if (newUrl.startsWith('web+urbitgraph://group/')) {


### PR DESCRIPTION
Treat website strings `'~'` as falsy. Ideally these would be filtered out in `/mar/ui-updates` but website URLs aren't units in `$docket-0` like image URLs are, and %hits shouldn't run its own "fork" of `$docket-0`.