### PR TITLE
Add background colour to mobile browser UI

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>hits</title>
-    <meta name="theme-color" content="#ffffff" />
+    <meta name="theme-color" content="#1E1414" />
     <link rel="icon" href="/src/assets/favicon.svg" sizes="any" type="image/svg+xml" />
     <link rel="mask-icon" href="/src/assets/safari-pinned-tab.svg" color="#000000" />
     <link rel="apple-touch-icon" sizes="180x180" href="/src/assets/apple-touch-icon.png" />


### PR DESCRIPTION
Removes white background from status bar at the top and visible when the user scrolls "below" the page and makes it the same background color as the app.

Before and after:

![](https://i.imgur.com/xuzbHD8.png)