### PR TITLE
Let users install multiple apps at once

### DIFF
--- a/ui/src/state/useDesksState.js
+++ b/ui/src/state/useDesksState.js
@@ -74,14 +74,12 @@ export default function useDesksState() {
         default:
           return;
       }
-
-    return;
     }
 
-    if ('del-charge' in chargesUpdate) {
-      // TODO add del-charge logic?
-      return;
-    }
+    // if ('del-charge' in chargesUpdate) {
+    //   // TODO add del-charge logic?
+    //   return;
+    // }
   }
 
   return {installedDesks, loadingDesks, receiveDesksUpdate}


### PR DESCRIPTION
This is the intended behaviour of the "GET" buttons but I never got around to fixing this up before soft-launch; turns out the problem was one line.

I've tested this a bit on a comet; you can download a handful of apps and instantly open them with no issue. Not yet clear to me if any issues I've seen with page loading times were due to having too many apps installing at once. Next test would be to spin up a new comet, fill up the All-Time list with apps from some pals and install all 40 apps at once.