### PR TITLE
Filter %neo desk from frontend results

### DIFF
--- a/desk/app/hits.hoon
+++ b/desk/app/hits.hoon
@@ -94,7 +94,9 @@
         rankings
       |=  =app
       ^-  ?
-      (gth (~(got by versions) app) base-version)
+      ?|  =(desk.app %neo)
+          (gth (~(got by versions) app) base-version)
+      ==
     |=  =app
     ^-  card
       :*  %give


### PR DESCRIPTION
`~met/neo` should only be installed on comets or moons, or by power users who understand the risks of installing the developer alpha on their live ship. This PR prevents any `%neo` desk from appearing in Hits' frontend, given the not-uncommon case that live ships republish a desk for their own ends. It does not prevent %neo installs being gossiped or stored on the backend.